### PR TITLE
Now works on windows

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -31,7 +31,9 @@ function init (ws) {
   contra.each(files, copy, done);
 
   function describe (src) {
-    var dest = src.replace(root, '.').replace(rname, '/perfschool-playground/$1/');
+    // workaround for windows
+    var _root = root.replace(/\\/g, '/'); 
+    var dest = src.replace(_root, '.').replace(rname, '/perfschool-playground/$1/').replace(/\//g, path.sep);
     mkdirp.sync(path.dirname(dest));
     return { src: src, dest: dest };
   }


### PR DESCRIPTION
The problem was that `glob` returns paths with the unix separator `/`
while `path` and `fs` do it with the default system separator, it depends if you are on unix, or windows

so, in windows

``` javascript
var root = path.join(__dirname, '..');
```

returns `C:\Users\Enzo\AppData\Roaming\npm\node_modules\perschool`

but in

``` javascript
function describe (src) {
    var dest = src.replace(root, '.').replace(rname, '/perfschool-playground/$1/');
    //etc
}
```

`src` has `C:/Users/Enzo/AppData/Roaming/npm/node_modules/perschool/{exercises}/problem.md`
and the `replace()` fails, happens the same with `rname`, as the RegEx only search for unix separator `/`.

so, I convert `root` separators to unix separators

``` javascript
var _root = root.replace(/\\/g, '/'); 
```

and then, after all the replaces, I turn the resulting string to the system default separator, with `path.sep`

``` javascript
src.replace(/\//g, path.sep);
```

if you find a better way to resolve this let me know, I know this isn't the most beautiful way =P
