### PR TITLE
Explicitly link localtunnel.me

### DIFF
--- a/exercises/using_the_pagespeed_api/problem.md
+++ b/exercises/using_the_pagespeed_api/problem.md
@@ -9,7 +9,7 @@ landing page `/`, as well as its stats.
 
 The exercise involves a very small dose of mad science. PageSpeed isn't really able to access
 a website that's hosted locally in your computer. However, we can use the `localtunnel`
-module to create a secure tunnel between your computer and http://localtunnel.me!
+module to create a secure tunnel between your computer and [http://localtunnel.me](http://localtunnel.me)!
 
 You just give it a `port` number and it'll create the bridge for you. Once that's out of
 the way, you can point `psi` to your `tunnel` and wait for the stats to come back.


### PR DESCRIPTION
There's an [issue with "marked"](https://github.com/chjj/marked/pull/638), the markdown parser that workshopper uses, that causes it to include a trailing "!" in a url that it autolinks. Changing this url to be an explicit link fixes that.

Before: it looks like the url is "http://localtunnel.me!" instead of "http://localtunnel.me":
![before](https://cloud.githubusercontent.com/assets/2023/9144154/1ee7f972-3d19-11e5-8fa9-232468a9384a.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/2023/9144168/303973ae-3d19-11e5-86e2-2f6ba3dcd87a.jpg)
