### PR TITLE
Include tmp in packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "serve-static": "1.9.2",
     "sinon": "1.14.1",
     "through2-concat": "1.0.1",
+    "tmp": "0.0.26",
     "webpagetest": "0.3.3",
     "webshot": "0.16.0",
     "workshopper": "2.5.0",


### PR DESCRIPTION
When running `perfschool` and selecting the "CREATING SPRITESHEETS" option, I encountered this error:

```
module.js:338
    throw err;
          ^
Error: Cannot find module 'tmp'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/perfschool/exercises/creating_spritesheets/exercise.js:4:11)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```

Installing the `tmp` package seems to fix this.
